### PR TITLE
Make a slight clarification.

### DIFF
--- a/CHIP-2021-03-12_Multiple_OP_RETURN_for_Bitcoin_Cash.md
+++ b/CHIP-2021-03-12_Multiple_OP_RETURN_for_Bitcoin_Cash.md
@@ -8,7 +8,7 @@
         Type: Technical
         Is consensus change: No
         Status: DRAFT
-        Last Edit Date: 2021-03-12
+        Last Edit Date: 2021-03-13
 
 ## Discussions
 
@@ -32,7 +32,7 @@ This proposal aims to correct this minor oversight in order to bring the full po
 
 ## Specification
 
-The only technical elements we've identified are changes to the existing node systems to remove the limit of a single OP_RETURN and to enforce the existing size limit for OP_RETURN across all aggregate OP_RETURNs in the transaction outputs. 
+The only technical elements we've identified are changes to the existing node systems to remove the limit of a single OP_RETURN and to enforce the existing size limit for OP_RETURN based outputs across all aggregate OP_RETURN outputs in the transaction.
 
 ## Current Implementations
 


### PR DESCRIPTION
This attempts to clarify the difference between the actual payload of an
OP_RETURN output (currently effectively 220 bytes) and the full output
sizes.
The latter includes the op_return opcode and the push opcodes.

So, simply said, this means that the new limit counts the size entire
output script, for each of the outputs using the op_return template.